### PR TITLE
Ensure config and sensor values are floats

### DIFF
--- a/miflora-card.js
+++ b/miflora-card.js
@@ -49,10 +49,10 @@ class MifloraCard extends HTMLElement {
     set hass(hass) {
         const config = this.config;
 
-        var _maxMoisture = config.max_moisture;
-        var _minMoisture = config.min_moisture;
-        var _minConductivity = config.min_conductivity;
-        var _minTemperature = config.min_termperature;
+        var _maxMoisture = parseFloat(config.max_moisture);
+        var _minMoisture = parseFloat(config.min_moisture);
+        var _minConductivity = parseFloat(config.min_conductivity);
+        var _minTemperature = parseFloat(config.min_termperature);
         var _sensors = [];
         for (var i = 0; i < config.entities.length; i++) {
             _sensors.push(config.entities[i].split(":")); // Split name away from sensor id
@@ -70,7 +70,7 @@ class MifloraCard extends HTMLElement {
             var _state = '';
             var _uom = '';
             if (hass.states[_sensor]) {
-                _state = hass.states[_sensor].state;
+                _state = parseFloat(hass.states[_sensor].state);
                 _uom = hass.states[_sensor].attributes.unit_of_measurement || "";
             } else {
                 _state = 'Invalid Sensor';


### PR DESCRIPTION
In certain conditions, values were interpreted as strings, not floats, which leads to wrong comparisons, and warnings.
Ensuring that we compare floats with floats mitigates this.